### PR TITLE
Look for binary in /usr/games/ rather than /usr/bin/

### DIFF
--- a/snapcraft-kubuntu/snapcraft.yaml
+++ b/snapcraft-kubuntu/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
   
     
   blinken:
-    command: qt5-launch usr/bin/blinken
+    command: qt5-launch usr/games/blinken
     plugs:
     - x11
     - unity7
@@ -111,6 +111,7 @@ parts:
     filesets:
       binaries:
         - usr/bin
+        - usr/games
       libraries:
         - lib/*
         - usr/lib/*


### PR DESCRIPTION
Blinken's binary is installed to /usr/games/ rather than /usr/bin/, so this PR includes that directory in the fileset and points qt5-launch to it there